### PR TITLE
Various additional properties and fixes

### DIFF
--- a/aiolivisi/aiolivisi.py
+++ b/aiolivisi/aiolivisi.py
@@ -190,6 +190,21 @@ class AioLivisi:
             "post", "action", payload=set_state_payload
         )
 
+    async def async_variable_set_value(
+        self, capability_id, value: bool
+    ) -> dict[str, Any]:
+        """Set the boolean variable state."""
+        set_value_payload: dict[str, Any] = {
+            "id": uuid.uuid4().hex,
+            "type": "SetState",
+            "namespace": "core.RWE",
+            "target": capability_id,
+            "params": {"value": {"type": "Constant", "value": value}},
+        }
+        return await self.async_send_authorized_request(
+            "post", "action", payload=set_value_payload
+        )
+
     async def async_vrcc_set_temperature(
         self, capability_id, target_temperature: float, is_avatar: bool
     ) -> dict[str, Any]:

--- a/aiolivisi/aiolivisi.py
+++ b/aiolivisi/aiolivisi.py
@@ -191,6 +191,19 @@ class AioLivisi:
             "post", "action", payload=set_state_payload
         )
 
+    async def async_set_onstate(self, capability_id, is_on: bool) -> dict[str, Any]:
+        """Set the onState for devices that support it."""
+        set_state_payload: dict[str, Any] = {
+            "id": uuid.uuid4().hex,
+            "type": "SetState",
+            "namespace": "core.RWE",
+            "target": capability_id,
+            "params": {"onState": {"type": "Constant", "value": is_on}},
+        }
+        return await self.async_send_authorized_request(
+            "post", "action", payload=set_state_payload
+        )
+
     async def async_variable_set_value(
         self, capability_id, value: bool
     ) -> dict[str, Any]:
@@ -220,6 +233,25 @@ class AioLivisi:
             "namespace": "core.RWE",
             "target": capability_id,
             "params": {params: {"type": "Constant", "value": target_temperature}},
+        }
+        return await self.async_send_authorized_request(
+            "post", "action", payload=set_state_payload
+        )
+
+    async def async_alarm_set_state(self, capability_id, is_on: bool) -> dict[str, Any]:
+        """Set the alert state."""
+
+        if is_on:
+            value = "Alarm"
+        else:
+            value = "None"
+
+        set_state_payload: dict[str, Any] = {
+            "id": uuid.uuid4().hex,
+            "type": "SetState",
+            "namespace": "core.RWE",
+            "target": capability_id,
+            "params": {"activeChannel": {"type": "Constant", "value": value}},
         }
         return await self.async_send_authorized_request(
             "post", "action", payload=set_state_payload

--- a/aiolivisi/aiolivisi.py
+++ b/aiolivisi/aiolivisi.py
@@ -238,25 +238,6 @@ class AioLivisi:
             "post", "action", payload=set_state_payload
         )
 
-    async def async_alarm_set_state(self, capability_id, is_on: bool) -> dict[str, Any]:
-        """Set the alert state."""
-
-        if is_on:
-            value = "Alarm"
-        else:
-            value = "None"
-
-        set_state_payload: dict[str, Any] = {
-            "id": uuid.uuid4().hex,
-            "type": "SetState",
-            "namespace": "core.RWE",
-            "target": capability_id,
-            "params": {"activeChannel": {"type": "Constant", "value": value}},
-        }
-        return await self.async_send_authorized_request(
-            "post", "action", payload=set_state_payload
-        )
-
     async def async_get_all_rooms(self) -> dict[str, Any]:
         """Get all the rooms from LIVISI configuration."""
         return await self.async_send_authorized_request("get", "location")

--- a/aiolivisi/aiolivisi.py
+++ b/aiolivisi/aiolivisi.py
@@ -149,13 +149,14 @@ class AioLivisi:
         capability_config = {}
 
         for capability in capabilities:
-            device_id = capability["device"].split("/")[-1]
-            if device_id not in capability_map:
-                capability_map[device_id] = {}
-                capability_config[device_id] = {}
-            capability_map[device_id][capability["type"]] = (
-                "/capability/" + capability["id"]
-            )
+            if "device" in capability:
+                device_id = capability["device"].split("/")[-1]
+                if device_id not in capability_map:
+                    capability_map[device_id] = {}
+                    capability_config[device_id] = {}
+                capability_map[device_id][capability["type"]] = (
+                    "/capability/" + capability["id"]
+                )
             if "config" in capability:
                 capability_config[device_id][capability["type"]] = capability["config"]
 

--- a/aiolivisi/const.py
+++ b/aiolivisi/const.py
@@ -10,6 +10,7 @@ AUTH_GRANT_TYPE: Final = "grant_type"
 REQUEST_TIMEOUT: Final = 2000
 
 ON_STATE: Final = "onState"
+VALUE: Final = "value"
 POINT_TEMPERATURE: Final = "pointTemperature"
 SET_POINT_TEMPERATURE: Final = "setpointTemperature"
 TEMPERATURE: Final = "temperature"

--- a/aiolivisi/websocket.py
+++ b/aiolivisi/websocket.py
@@ -76,7 +76,9 @@ class Websocket:
             if event_data.type == EVENT_STATE_CHANGED:
                 if ON_STATE in event_data.properties.keys():
                     event_data.onState = event_data.properties.get(ON_STATE)
-                elif VALUE in event_data.properties.keys():
+                elif VALUE in event_data.properties.keys() and isinstance(
+                    event_data.properties.get(VALUE), bool
+                ):
                     event_data.onState = event_data.properties.get(VALUE)
                 if SET_POINT_TEMPERATURE in event_data.properties.keys():
                     event_data.vrccData = event_data.properties.get(

--- a/aiolivisi/websocket.py
+++ b/aiolivisi/websocket.py
@@ -12,6 +12,7 @@ from .const import (
     AVATAR_PORT,
     IS_REACHABLE,
     ON_STATE,
+    VALUE,
     IS_OPEN,
     SET_POINT_TEMPERATURE,
     POINT_TEMPERATURE,
@@ -66,6 +67,7 @@ class Websocket:
         """Used when data is transmited using the websocket."""
         async for message in websocket:
             event_data = LivisiEvent.parse_raw(message)
+
             if "device" in event_data.source:
                 event_data.source = event_data.source.replace("/device/", "")
             if event_data.properties is None:
@@ -74,6 +76,8 @@ class Websocket:
             if event_data.type == EVENT_STATE_CHANGED:
                 if ON_STATE in event_data.properties.keys():
                     event_data.onState = event_data.properties.get(ON_STATE)
+                elif VALUE in event_data.properties.keys():
+                    event_data.onState = event_data.properties.get(VALUE)
                 if SET_POINT_TEMPERATURE in event_data.properties.keys():
                     event_data.vrccData = event_data.properties.get(
                         SET_POINT_TEMPERATURE


### PR DESCRIPTION
## Add support for VariableActuator
Boolean variables like "vacation mode" can also be represented as a switch, but they have a different representation in Livisi (VariableActuator with capability BooleanStateActuator). We need to support setting the value and getting it as the is_on property.

## Add generic set_onstate
This does the same as pss_set_state but the name also fits for sirens or other on/off actuators

## Fix error handling on websocket
Don't stop parsing messages if one message cannot be parsed or does not have a properties field. Just continue with the next message. Additionally, checking for ValidationErrors should be done directly where the LivisiEvent is parsed, not outside.